### PR TITLE
fix: handle bool values for data match

### DIFF
--- a/BlinkID/lib/recognizers/usdl_combined_recognizer.dart
+++ b/BlinkID/lib/recognizers/usdl_combined_recognizer.dart
@@ -97,7 +97,15 @@ class UsdlCombinedRecognizerResult extends RecognizerResult {
 
         this.digitalSignatureVersion = nativeResult['digitalSignatureVersion'];
 
-        this.documentDataMatch = DataMatchResult.values[nativeResult["documentDataMatch"]];
+        if (nativeResult["documentDataMatch"] is int) {
+          this.documentDataMatch = DataMatchResult.values[nativeResult["documentDataMatch"]];
+        } else if (nativeResult["documentDataMatch"] == true) {
+          this.documentDataMatch = DataMatchResult.Success;
+        }else if (nativeResult["documentDataMatch"] == false) {
+          this.documentDataMatch = DataMatchResult.Failed;
+        } else {
+          this.documentDataMatch = DataMatchResult.NotPerformed;
+        }
 
         this.faceImage = nativeResult['faceImage'];
 


### PR DESCRIPTION
## Why
This recognizer fails on IOS. Stack trace (and code comments) indicate that the native result is returning a boolean which the flutter code is then trying to use to access an enum value. This fails with a "bool is not an int" error.

## What
Still need to support the Android case where, presumably, the native result does return an int, so allow for that, then map to success and failure (true and false) with a fallback to not performed.